### PR TITLE
Add `giatools.Image` class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ __pycache__
 *.swp
 tests/*-out-*
 /.venv
+/env
 /.coverage

--- a/giatools/__init__.py
+++ b/giatools/__init__.py
@@ -1,3 +1,5 @@
+from .image import Image  # noqa: F401
+
 VERSION_MAJOR = 0
 VERSION_MINOR = 3
 VERSION_PATCH = 1

--- a/giatools/__init__.py
+++ b/giatools/__init__.py
@@ -2,6 +2,6 @@ from .image import Image  # noqa: F401
 
 VERSION_MAJOR = 0
 VERSION_MINOR = 3
-VERSION_PATCH = 1
+VERSION_PATCH = 2
 
 VERSION = '%d.%d%s' % (VERSION_MAJOR, VERSION_MINOR, '.%d' % VERSION_PATCH if VERSION_PATCH > 0 else '')

--- a/giatools/image.py
+++ b/giatools/image.py
@@ -12,8 +12,10 @@ from typing import (
 
 import numpy as np
 
-from . import io
-from . import util
+from . import (
+    io,
+    util,
+)
 
 
 class Image:

--- a/giatools/image.py
+++ b/giatools/image.py
@@ -5,6 +5,8 @@ Distributed under the MIT license.
 See file LICENSE for detail or copy at https://opensource.org/licenses/MIT
 """
 
+from __future__ import annotations
+
 from typing import (
     Optional,
     Self,

--- a/giatools/image.py
+++ b/giatools/image.py
@@ -5,16 +5,15 @@ Distributed under the MIT license.
 See file LICENSE for detail or copy at https://opensource.org/licenses/MIT
 """
 
-from .typing import (
-    Optional,
-    Self,
-)
-
 import numpy as np
 
 from . import (
     io,
     util,
+)
+from .typing import (
+    Optional,
+    Self,
 )
 
 

--- a/giatools/image.py
+++ b/giatools/image.py
@@ -42,12 +42,12 @@ class Image:
         Squeeze the axes of the image to match the axes.
 
         Raises:
-            ValueError: If one of the axis cannot be squeezed.
-            AssertionError: If `axes` is not a subset of the image axes.
+            ValueError: If one of the axis cannot be squeezed or `axes` is not a subset of the image axes.
         """
-        assert (
-            frozenset(axes) <= frozenset(self.axes)
-        ), f'Cannot squeeze axes "{axes}" from image with axes "{self.axes}"'
+
+        if not (frozenset(axes) <= frozenset(self.axes)):
+            raise ValueError(f'Cannot squeeze axes "{axes}" from image with axes "{self.axes}"')
+
         s = tuple(axis_pos for axis_pos, axis in enumerate(self.axes) if axis not in axes)
         squeezed_axes = util.str_without_positions(self.axes, s)
         squeezed_image = Image(data=self.data.squeeze(axis=s), axes=squeezed_axes, original_axes=self.original_axes)
@@ -56,10 +56,13 @@ class Image:
     def reorder_axes_like(self, axes: str) -> Self:
         """
         Reorder the axes of the image to match the given order.
+
+        Raises:
+            ValueError: If there are spurious, missing, or ambiguous axes.
         """
-        assert (
-            frozenset(axes) == frozenset(self.axes) and len(frozenset(axes)) == len(axes)
-        ), f'Cannot reorder axes like "{axes}" of image with axes "{self.axes}"'
+        if not (frozenset(axes) == frozenset(self.axes) and len(frozenset(axes)) == len(axes)):
+            raise ValueError(f'Cannot reorder axes like "{axes}" of image with axes "{self.axes}"')
+
         reordered_data = self.data
         reordered_axes = self.axes
         for dst, axis in enumerate(axes):
@@ -78,7 +81,8 @@ class Image:
             AssertionError: If `axes` is ambiguous.
             ValueError: If one of the axis cannot be squeezed.
         """
-        assert len(frozenset(axes)) == len(axes), f'Axes "{axes}" is ambiguous'
+        if not (len(frozenset(axes)) == len(axes)):
+            raise AssertionError(f'Axes "{axes}" is ambiguous')
 
         # Add missing axes
         complete_data = self.data

--- a/giatools/image.py
+++ b/giatools/image.py
@@ -1,0 +1,63 @@
+"""
+Copyright 2017-2025 Leonid Kostrykin, Biomedical Computer Vision Group, Heidelberg University.
+
+Distributed under the MIT license.
+See file LICENSE for detail or copy at https://opensource.org/licenses/MIT
+"""
+
+from typing import Self
+
+import numpy as np
+
+from . import io
+from . import util
+
+
+class Image:
+    """
+    Represents an image (image pixel/voxel data and the corresponding axes metadata).
+    """
+
+    def __init__(self, data: np.ndarray, axes: str):
+        self.data = data
+        self.axes = axes
+
+    @staticmethod
+    def read(*args, **kwargs) -> Self:
+        """
+        Read an image from file.
+        """
+        return Image(*io.imread(*args, ret_axes=True, **kwargs))
+
+    def squeeze_like(self, axes: str) -> Self:
+        """
+        Squeeze the axes of the image to match the axes.
+
+        Raises:
+            ValueError: If one of the axis cannot be squeezed.
+            AssertionError: If `axes` is not a subset of the image axes.
+        """
+        assert (
+            frozenset(axes) <= frozenset(self.axes)
+        ), f'Cannot squeeze axes "{axes}" from image with axes "{self.axes}"'
+        s = tuple(axis_pos for axis_pos, axis in enumerate(self.axes) if axis not in axes)
+        squeezed_axes = util.str_without_positions(self.axes, s)
+        squeezed_image = Image(data=self.data.squeeze(axis=s), axes=squeezed_axes)
+        return squeezed_image.reorder_axes_like(axes)
+
+    def reorder_axes_like(self, axes: str) -> Self:
+        """
+        Reorder the axes of the image to match the given order.
+        """
+        assert (
+            frozenset(axes) == frozenset(self.axes) and len(frozenset(axes)) == len(axes)
+        ), f'Cannot reorder axes like "{axes}" of image with axes "{self.axes}"'
+        reordered_data = self.data
+        reordered_axes = self.axes
+        for dst, axis in enumerate(axes):
+            src = reordered_axes.index(axis)
+            if src != dst:
+                reordered_data = np.moveaxis(reordered_data, src, dst)
+                reordered_axes = util.move_char(reordered_axes, src, dst)
+        assert reordered_axes == axes, f'Failed to reorder axes "{self.axes}" to "{axes}", got "{reordered_axes}"'
+        return Image(data=reordered_data, axes=axes)

--- a/giatools/image.py
+++ b/giatools/image.py
@@ -5,7 +5,10 @@ Distributed under the MIT license.
 See file LICENSE for detail or copy at https://opensource.org/licenses/MIT
 """
 
-from typing import Self
+from typing import (
+    Optional,
+    Self,
+)
 
 import numpy as np
 
@@ -18,16 +21,18 @@ class Image:
     Represents an image (image pixel/voxel data and the corresponding axes metadata).
     """
 
-    def __init__(self, data: np.ndarray, axes: str):
+    def __init__(self, data: np.ndarray, axes: str, original_axes: Optional[str] = None):
         self.data = data
         self.axes = axes
+        self.original_axes = original_axes
 
     @staticmethod
     def read(*args, **kwargs) -> Self:
         """
         Read an image from file.
         """
-        return Image(*io.imread(*args, ret_axes=True, **kwargs))
+        data, original_axes = io.imread(*args, ret_axes=True, **kwargs)
+        return Image(data, 'TZYXC', original_axes=original_axes)
 
     def squeeze_like(self, axes: str) -> Self:
         """

--- a/giatools/image.py
+++ b/giatools/image.py
@@ -5,9 +5,7 @@ Distributed under the MIT license.
 See file LICENSE for detail or copy at https://opensource.org/licenses/MIT
 """
 
-from __future__ import annotations
-
-from typing import (
+from .typing import (
     Optional,
     Self,
 )

--- a/giatools/io.py
+++ b/giatools/io.py
@@ -5,8 +5,8 @@ Distributed under the MIT license.
 See file LICENSE for detail or copy at https://opensource.org/licenses/MIT
 """
 
-import numpy as np
 import skimage.io
+import warnings
 
 import giatools.util
 
@@ -17,9 +17,9 @@ except ImportError:
 
 
 @giatools.util.silent
-def imread(*args, ret_axes: bool = False, **kwargs):
+def imreadraw(*args, **kwargs):
     """
-    Wrapper for loading images, muting non-fatal errors, and normalizing the image axes like ``TZYXC``.
+    Wrapper for loading images, muting non-fatal errors.
 
     When using ``skimage.io.imread`` to read an image file, sometimes errors can be reported although the image file
     will be read successfully. In those cases, Galaxy might detect the errors on stdout or stderr, and assume that the
@@ -29,23 +29,11 @@ def imread(*args, ret_axes: bool = False, **kwargs):
     Image loading is first attempted using `tifffile` (if available, more reliable for loading TIFF files), and if
     that fails (e.g., because the file is not a TIFF file), falls back to ``skimage.io.imread``.
 
-    The image axes are normalized like ``TZYXC``, treating sample axis ``S`` as an alias for the channel axis ``C``.
-    For images which cannot be read by `tifffile`, two- and three-dimensional data is supported. Two-dimensional images
-    are assumed to be in ``YX`` axes order, and three-dimensional images are assumed to be in ``YXC`` axes order.
-
-    Returns:
-        The returned object depends on the value of the `ret_axes` parameter:
-        - If `ret_axes` is `True`, a tuple `(im_arr, axes)` is returned, where `im_arr` is the image data as a
-          five-dimensional NumPy array, and `axes` is the original axes of the image.
-        - If `ret_axes` is `False`, only the image data as a five-dimensional NumPy array is returned.
+    Returns a tuple `(im_arr, axes)` where `im_arr` is the image data as a NumPy array, and `axes` are the axes of the
+    image. Normalization is performed, treating sample axis ``S`` as an alias for the channel axis ``C``. For images
+    which cannot be read by `tifffile`, two- and three-dimensional data is supported. Two-dimensional images are
+    assumed to be in ``YX`` axes order, and three-dimensional images are assumed to be in ``YXC`` axes order.
     """
-
-    # Helper function to return the result based on the value of `ret_axes`
-    def result(im_arr: np.ndarray, axes: str, ret_axes: bool):
-        if ret_axes:
-            return im_arr, axes
-        else:
-            return im_arr
 
     # First, try to read the image using `tifffile` (will only succeed if it is a TIFF file)
     if tifffile is not None:
@@ -53,8 +41,7 @@ def imread(*args, ret_axes: bool = False, **kwargs):
 
             with tifffile.TiffFile(*args, **kwargs) as im_file:
                 assert len(im_file.series) == 1, f'Image has unsupported number of series: {len(im_file.series)}'
-                original_axes = im_file.series[0].axes
-                im_axes = original_axes
+                im_axes = im_file.series[0].axes
 
                 # Verify that the image format is supported
                 assert (
@@ -70,53 +57,8 @@ def imread(*args, ret_axes: bool = False, **kwargs):
                 # Read the image data
                 im_arr = im_file.asarray()
 
-                # Step 1. In the three steps below, the optional axes are added, of if they arent't there yet:
-
-                # (1.1) Append "C" axis if not present yet
-                if im_axes.find('C') == -1:
-                    im_arr = im_arr[..., None]
-                    im_axes += 'C'
-
-                # (1.2) Append "Z" axis if not present yet
-                if im_axes.find('Z') == -1:
-                    im_arr = im_arr[..., None]
-                    im_axes += 'Z'
-
-                # (1.3) Append "T" axis if not present yet
-                if im_axes.find('T') == -1:
-                    im_arr = im_arr[..., None]
-                    im_axes += 'T'
-
-                # Step 2. All supported axes are there now. Normalize the order of the axes:
-
-                # (2.1) Normalize order of axes "Y" and "X"
-                ypos = im_axes.find('Y')
-                xpos = im_axes.find('X')
-                if ypos > xpos:
-                    im_arr = im_arr.swapaxes(ypos, xpos)
-                    im_axes = giatools.util.swap_char(im_axes, xpos, ypos)
-
-                # (2.2) Normalize the position of the "C" axis (should be last)
-                cpos = im_axes.find('C')
-                if cpos < len(im_axes) - 1:
-                    im_arr = np.moveaxis(im_arr, cpos, -1)
-                    im_axes = giatools.util.move_char(im_axes, cpos, -1)
-
-                # (2.3) Normalize the position of the "T" axis (should be first)
-                tpos = im_axes.find('T')
-                if tpos != 0:
-                    im_arr = np.moveaxis(im_arr, tpos, 0)
-                    im_axes = giatools.util.move_char(im_axes, tpos, 0)
-
-                # (2.4) Normalize the position of the "Z" axis (should be second)
-                zpos = im_axes.find('Z')
-                if zpos != 1:
-                    im_arr = np.moveaxis(im_arr, zpos, 1)
-                    im_axes = giatools.util.move_char(im_axes, zpos, 1)
-
-                # Verify that the normalizations were successful
-                assert im_axes == 'TZYXC', f'Image axis normalization failed: {im_axes}'
-                return result(im_arr, original_axes, ret_axes)
+                # Return the image data and axes
+                return im_arr, im_axes
 
         except tifffile.TiffFileError:
             pass  # not a TIFF file
@@ -125,16 +67,32 @@ def imread(*args, ret_axes: bool = False, **kwargs):
     im_arr = skimage.io.imread(*args, **kwargs)
 
     # Verify that the image format is supported
-    assert im_arr.ndim in (2, 3), f"Image has unsupported dimension: {im_arr.ndim}"
+    assert im_arr.ndim in (2, 3), f'Image has unsupported dimension: {im_arr.ndim}'
 
-    # Normalize the axes
-    if im_arr.ndim == 2:  # Append "C" axis if not present yet
-        im_arr = im_arr[..., None]
-        original_axes = 'YX'
+    # Determine the axes
+    if im_arr.ndim == 2:
+        im_axes = 'YX'
     else:
-        original_axes = 'YXC'
-    im_arr = im_arr[None, None, ...]  # Prepend "T" and "Z" axes
+        im_axes = 'YXC'
 
-    # Verify that the normalizations were successful
-    assert im_arr.ndim == 5, "Image axis normalization failed"
-    return result(im_arr, original_axes, ret_axes)
+    # Return the image data and axes
+    return im_arr, im_axes
+
+
+def imread(*args, ret_axes: bool = False, **kwargs):
+    """
+    Wrapper for loading images, muting non-fatal errors and normalizing the image axes like ``TZYXC``.
+
+    .. deprecated:: 0.3.2
+       Use :meth:`giatools.image.Image.read` instead.
+    """
+
+    warnings.warn(
+        'imread function is deprecated and will be removed in a future release. Use Image.read instead.',
+        DeprecationWarning,
+        stacklevel=2
+    )
+
+    from .image import Image
+    img = Image.read(*args, normalize_axes='TZYXC', **kwargs)
+    return img.data

--- a/giatools/io.py
+++ b/giatools/io.py
@@ -5,8 +5,9 @@ Distributed under the MIT license.
 See file LICENSE for detail or copy at https://opensource.org/licenses/MIT
 """
 
-import skimage.io
 import warnings
+
+import skimage.io
 
 import giatools.util
 

--- a/giatools/typing.py
+++ b/giatools/typing.py
@@ -1,0 +1,6 @@
+import sys
+
+if sys.version_info < (3, 11):
+    from typing_extensions import *  # noqa: F401, F403
+else:
+    from typing import *  # noqa: F401, F403

--- a/giatools/util.py
+++ b/giatools/util.py
@@ -7,6 +7,7 @@ See file LICENSE for detail or copy at https://opensource.org/licenses/MIT
 
 import contextlib
 import os
+import warnings
 
 import numpy as np
 import skimage.util
@@ -69,6 +70,18 @@ def move_char(s: str, pos_src: int, pos_dst: int) -> str:
 
 
 def swap_char(s: str, pos1: int, pos2: int) -> str:
+    """
+    Swaps the characters at positions `pos1` and `pos2` in the string `s`.
+
+    .. deprecated:: 0.3.2
+    """
+
+    warnings.warn(
+        'swap_char function is deprecated and will be removed in a future release.',
+        DeprecationWarning,
+        stacklevel=2
+    )
+
     s_list = list(s)
     s_list[pos1], s_list[pos2] = s_list[pos2], s_list[pos1]
     return ''.join(s_list)

--- a/giatools/util.py
+++ b/giatools/util.py
@@ -12,6 +12,8 @@ import warnings
 import numpy as np
 import skimage.util
 
+from .typing import Iterable
+
 
 def silent(func):
     """
@@ -87,7 +89,7 @@ def swap_char(s: str, pos1: int, pos2: int) -> str:
     return ''.join(s_list)
 
 
-def str_without_positions(s: str, positions: list[int]) -> str:
+def str_without_positions(s: str, positions: Iterable[int]) -> str:
     """
     Returns the string `s` with the `characters` removed from it.
     """

--- a/giatools/util.py
+++ b/giatools/util.py
@@ -72,3 +72,12 @@ def swap_char(s: str, pos1: int, pos2: int) -> str:
     s_list = list(s)
     s_list[pos1], s_list[pos2] = s_list[pos2], s_list[pos1]
     return ''.join(s_list)
+
+
+def str_without_positions(s: str, positions: list[int]) -> str:
+    """
+    Returns the string `s` with the `characters` removed from it.
+    """
+    for pos in sorted(positions, reverse=True):
+        s = s[:pos] + s[pos + 1:]
+    return s

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy>=1.18
 scikit-image>=0.18
 pandas>=1
+typing-extensions

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -95,17 +95,17 @@ class Image__reorder_axes_like(unittest.TestCase):
         self.assertEqual(img_reordered.original_axes, test1_original_axes)
 
     def test__spurious_axis(self):
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             self.img1.reorder_axes_like('ZTCYXW')
 
     def test__missing_axis(self):
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             self.img1.reorder_axes_like('ZTCY')
 
     def test__ambigious_axis(self):
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             self.img1.reorder_axes_like('ZTCYXX')
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             self.img1.reorder_axes_like('ZTCXX')
 
 
@@ -144,11 +144,11 @@ class Image__squeeze_like(unittest.TestCase):
             self.img1.squeeze_like('TCYX')
 
     def test__spurious_axis(self):
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             self.img1.squeeze_like('ZCYXW')
 
     def test__ambigious_axis(self):
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             self.img1.squeeze_like('ZCYXX')
 
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,0 +1,94 @@
+import unittest
+import unittest.mock
+
+import numpy as np
+
+import giatools.image
+
+# This tests require that the `tifffile` package is installed.
+assert giatools.io.tifffile is not None
+
+
+# Define test image data
+test_data1 = np.random.randint(0, 255, (1, 2, 26, 32, 3), dtype=np.uint8)
+test_axes1 = 'TZYXC'
+test_data2 = np.random.randint(0, 255, (1, 1, 32, 26, 1), dtype=np.uint8)
+test_axes2 = 'ZTYXC'
+
+
+class Image__read(unittest.TestCase):
+
+    def test__input1(self):
+        img = giatools.image.Image.read('tests/data/input1_uint8_yx.tif')
+        self.assertEqual(img.data.mean(), 63.66848655158571)
+        self.assertEqual(img.data.shape, (1, 1, 265, 329, 1))
+        self.assertEqual(img.axes, 'YX')
+
+
+class Image__reorder_axes_like(unittest.TestCase):
+
+    def setUp(self):
+        self.img1 = giatools.image.Image(data=test_data1.copy(), axes=test_axes1)
+
+    def test(self):
+        img_reordered = self.img1.reorder_axes_like('ZTCYX')
+        self.assertEqual(img_reordered.axes, 'ZTCYX')
+        self.assertEqual(img_reordered.data.shape, (2, 1, 3, 26, 32))
+
+    def test__identity(self):
+        img_reordered = self.img1.reorder_axes_like(test_axes1)
+        self.assertEqual(img_reordered.axes, test_axes1)
+        self.assertEqual(img_reordered.data.shape, test_data1.shape)
+
+    def test__spurious_axis(self):
+        with self.assertRaises(AssertionError):
+            self.img1.reorder_axes_like('ZTCYXW')
+
+    def test__missing_axis(self):
+        with self.assertRaises(AssertionError):
+            self.img1.reorder_axes_like('ZTCY')
+
+    def test__ambigious_axis(self):
+        with self.assertRaises(AssertionError):
+            self.img1.reorder_axes_like('ZTCYXX')
+        with self.assertRaises(AssertionError):
+            self.img1.reorder_axes_like('ZTCXX')
+
+
+class Image__squeeze_like(unittest.TestCase):
+
+    def setUp(self):
+        self.img1 = giatools.image.Image(data=test_data1, axes=test_axes1)
+        self.img2 = giatools.image.Image(data=test_data2, axes=test_axes2)
+
+    def test__no_squeeze(self):
+        img_squeezed = self.img1.squeeze_like('ZTCYX')
+        self.assertEqual(img_squeezed.axes, 'ZTCYX')
+        self.assertEqual(img_squeezed.data.shape, (2, 1, 3, 26, 32))
+
+    def test__squeeze_1(self):
+        img_squeezed = self.img1.squeeze_like('ZCYX')
+        self.assertEqual(img_squeezed.axes, 'ZCYX')
+        self.assertEqual(img_squeezed.data.shape, (2, 3, 26, 32))
+
+    def test__squeeze_2(self):
+        img_squeezed = self.img2.squeeze_like('XYC')
+        self.assertEqual(img_squeezed.axes, 'XYC')
+        self.assertEqual(img_squeezed.data.shape, (26, 32, 1))
+
+    def test__squeeze_3(self):
+        img_squeezed = self.img2.squeeze_like('XY')
+        self.assertEqual(img_squeezed.axes, 'XY')
+        self.assertEqual(img_squeezed.data.shape, (26, 32))
+
+    def test__squeeze_illegal_axis(self):
+        with self.assertRaises(ValueError):
+            self.img1.squeeze_like('TCYX')
+
+    def test__spurious_axis(self):
+        with self.assertRaises(AssertionError):
+            self.img1.squeeze_like('ZCYXW')
+
+    def test__ambigious_axis(self):
+        with self.assertRaises(AssertionError):
+            self.img1.squeeze_like('ZCYXX')

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -22,7 +22,8 @@ class Image__read(unittest.TestCase):
         img = giatools.image.Image.read('tests/data/input1_uint8_yx.tif')
         self.assertEqual(img.data.mean(), 63.66848655158571)
         self.assertEqual(img.data.shape, (1, 1, 265, 329, 1))
-        self.assertEqual(img.axes, 'YX')
+        self.assertEqual(img.original_axes, 'YX')
+        self.assertEqual(img.axes, 'TZYXC')
 
 
 class Image__reorder_axes_like(unittest.TestCase):

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -10,10 +10,12 @@ assert giatools.io.tifffile is not None
 
 
 # Define test image data
-test_data1 = np.random.randint(0, 255, (1, 2, 26, 32, 3), dtype=np.uint8)
-test_axes1 = 'TZYXC'
-test_data2 = np.random.randint(0, 255, (1, 1, 32, 26, 1), dtype=np.uint8)
-test_axes2 = 'ZTYXC'
+test1_data = np.random.randint(0, 255, (1, 2, 26, 32, 3), dtype=np.uint8)
+test1_axes = 'TZYXC'
+test1_original_axes = 'ZXYC'
+test2_data = np.random.randint(0, 255, (1, 1, 32, 26, 1), dtype=np.uint8)
+test2_axes = 'ZTYXC'
+test2_original_axes = 'YXC'
 
 
 class Image__read(unittest.TestCase):
@@ -25,21 +27,72 @@ class Image__read(unittest.TestCase):
         self.assertEqual(img.original_axes, 'YX')
         self.assertEqual(img.axes, 'TZYXC')
 
+    def test__input2(self):
+        img = giatools.image.Image.read('tests/data/input2_uint8_yx.tif')
+        self.assertEqual(img.data.mean(), 9.543921821305842)
+        self.assertEqual(img.data.shape, (1, 1, 96, 97, 1))
+        self.assertEqual(img.original_axes, 'YX')
+        self.assertEqual(img.axes, 'TZYXC')
+
+    def test__input3(self):
+        img = giatools.image.Image.read('tests/data/input3_uint16_zyx.tif')
+        self.assertEqual(img.data.shape, (1, 5, 198, 356, 1))
+        self.assertEqual(img.data.mean(), 1259.6755334241288)
+        self.assertEqual(img.original_axes, 'ZYX')
+        self.assertEqual(img.axes, 'TZYXC')
+
+    def test__input4(self):
+        img = giatools.image.Image.read('tests/data/input4_uint8.png')
+        self.assertEqual(img.data.shape, (1, 1, 10, 10, 3))
+        self.assertEqual(img.data.mean(), 130.04)
+        self.assertEqual(img.original_axes, 'YXC')
+        self.assertEqual(img.axes, 'TZYXC')
+
+    def test__input5(self):
+        img = giatools.image.Image.read('tests/data/input5_uint8_cyx.tif')
+        self.assertEqual(img.data.shape, (1, 1, 8, 16, 2))
+        self.assertEqual(img.data.mean(), 22.25390625)
+        self.assertEqual(img.original_axes, 'CYX')
+        self.assertEqual(img.axes, 'TZYXC')
+
+    def test__input6(self):
+        img = giatools.image.Image.read('tests/data/input6_uint8_zyx.tif')
+        self.assertEqual(img.data.shape, (1, 25, 8, 16, 1))
+        self.assertEqual(img.data.mean(), 26.555)
+        self.assertEqual(img.original_axes, 'ZYX')
+        self.assertEqual(img.axes, 'TZYXC')
+
+    def test__input7(self):
+        img = giatools.image.Image.read('tests/data/input7_uint8_zcyx.tif')
+        self.assertEqual(img.data.shape, (1, 25, 50, 50, 2))
+        self.assertEqual(img.data.mean(), 14.182152)
+        self.assertEqual(img.original_axes, 'ZCYX')
+        self.assertEqual(img.axes, 'TZYXC')
+
+    def test__input8(self):
+        img = giatools.image.Image.read('tests/data/input8_uint16_tyx.tif')
+        self.assertEqual(img.data.shape, (5, 1, 49, 56, 1))
+        self.assertEqual(img.data.mean(), 5815.486880466472)
+        self.assertEqual(img.original_axes, 'TYX')
+        self.assertEqual(img.axes, 'TZYXC')
+
 
 class Image__reorder_axes_like(unittest.TestCase):
 
     def setUp(self):
-        self.img1 = giatools.image.Image(data=test_data1.copy(), axes=test_axes1)
+        self.img1 = giatools.image.Image(data=test1_data.copy(), axes=test1_axes, original_axes=test1_original_axes)
 
     def test(self):
         img_reordered = self.img1.reorder_axes_like('ZTCYX')
         self.assertEqual(img_reordered.axes, 'ZTCYX')
         self.assertEqual(img_reordered.data.shape, (2, 1, 3, 26, 32))
+        self.assertEqual(img_reordered.original_axes, test1_original_axes)
 
     def test__identity(self):
-        img_reordered = self.img1.reorder_axes_like(test_axes1)
-        self.assertEqual(img_reordered.axes, test_axes1)
-        self.assertEqual(img_reordered.data.shape, test_data1.shape)
+        img_reordered = self.img1.reorder_axes_like(test1_axes)
+        self.assertEqual(img_reordered.axes, test1_axes)
+        self.assertEqual(img_reordered.data.shape, test1_data.shape)
+        self.assertEqual(img_reordered.original_axes, test1_original_axes)
 
     def test__spurious_axis(self):
         with self.assertRaises(AssertionError):
@@ -59,28 +112,32 @@ class Image__reorder_axes_like(unittest.TestCase):
 class Image__squeeze_like(unittest.TestCase):
 
     def setUp(self):
-        self.img1 = giatools.image.Image(data=test_data1, axes=test_axes1)
-        self.img2 = giatools.image.Image(data=test_data2, axes=test_axes2)
+        self.img1 = giatools.image.Image(data=test1_data, axes=test1_axes, original_axes=test1_original_axes)
+        self.img2 = giatools.image.Image(data=test2_data, axes=test2_axes, original_axes=test2_original_axes)
 
     def test__no_squeeze(self):
         img_squeezed = self.img1.squeeze_like('ZTCYX')
         self.assertEqual(img_squeezed.axes, 'ZTCYX')
         self.assertEqual(img_squeezed.data.shape, (2, 1, 3, 26, 32))
+        self.assertEqual(img_squeezed.original_axes, test1_original_axes)
 
     def test__squeeze_1(self):
         img_squeezed = self.img1.squeeze_like('ZCYX')
         self.assertEqual(img_squeezed.axes, 'ZCYX')
         self.assertEqual(img_squeezed.data.shape, (2, 3, 26, 32))
+        self.assertEqual(img_squeezed.original_axes, test1_original_axes)
 
     def test__squeeze_2(self):
         img_squeezed = self.img2.squeeze_like('XYC')
         self.assertEqual(img_squeezed.axes, 'XYC')
         self.assertEqual(img_squeezed.data.shape, (26, 32, 1))
+        self.assertEqual(img_squeezed.original_axes, test2_original_axes)
 
     def test__squeeze_3(self):
         img_squeezed = self.img2.squeeze_like('XY')
         self.assertEqual(img_squeezed.axes, 'XY')
         self.assertEqual(img_squeezed.data.shape, (26, 32))
+        self.assertEqual(img_squeezed.original_axes, test2_original_axes)
 
     def test__squeeze_illegal_axis(self):
         with self.assertRaises(ValueError):
@@ -93,3 +150,20 @@ class Image__squeeze_like(unittest.TestCase):
     def test__ambigious_axis(self):
         with self.assertRaises(AssertionError):
             self.img1.squeeze_like('ZCYXX')
+
+
+class Image__normalize_axes_like(unittest.TestCase):
+
+    def test1(self):
+        img = giatools.image.Image(data=test1_data, axes=test1_axes, original_axes=test1_original_axes)
+        img_normalized = img.normalize_axes_like(test1_original_axes)
+        self.assertEqual(img_normalized.axes, test1_original_axes)
+        self.assertEqual(img_normalized.data.shape, (2, 32, 26, 3))
+        self.assertEqual(img_normalized.original_axes, test1_original_axes)
+
+    def test2(self):
+        img = giatools.image.Image(data=test2_data, axes=test2_axes, original_axes=test2_original_axes)
+        img_normalized = img.normalize_axes_like(test2_original_axes)
+        self.assertEqual(img_normalized.axes, test2_original_axes)
+        self.assertEqual(img_normalized.data.shape, (32, 26, 1))
+        self.assertEqual(img_normalized.original_axes, test2_original_axes)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -20,6 +20,12 @@ class imread__with_tifffile(unittest.TestCase):
         self.assertEqual(img.mean(), 63.66848655158571)
         self.assertEqual(img.shape, (1, 1, 265, 329, 1))
 
+    def test__input1__ret_axes(self):
+        img, axes = giatools.io.imread('tests/data/input1_uint8_yx.tif', ret_axes=True)
+        self.assertEqual(img.mean(), 63.66848655158571)
+        self.assertEqual(img.shape, (1, 1, 265, 329, 1))
+        self.assertEqual(axes, 'YX')
+
     def test__input2(self):
         img = giatools.io.imread('tests/data/input2_uint8_yx.tif')
         self.assertEqual(img.mean(), 9.543921821305842)
@@ -43,6 +49,15 @@ class imread__with_tifffile(unittest.TestCase):
         img = giatools.io.imread('tests/data/input4_uint8.png')
         self.assertEqual(img.shape, (1, 1, 10, 10, 3))
         self.assertEqual(img.mean(), 130.04)
+
+    def test__input4__ret_axes(self):
+        """
+        Same as `test__input4`, but with `ret_axes=True`.
+        """
+        img, axes = giatools.io.imread('tests/data/input4_uint8.png', ret_axes=True)
+        self.assertEqual(img.shape, (1, 1, 10, 10, 3))
+        self.assertEqual(img.mean(), 130.04)
+        self.assertEqual(axes, 'YXC')
 
     def test__input5(self):
         """

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -9,27 +9,23 @@ import giatools.io
 assert giatools.io.tifffile is not None
 
 
-class imread__with_tifffile(unittest.TestCase):
+class imreadraw__with_tifffile(unittest.TestCase):
 
     def setUp(self):
         # Verify that the `tifffile` package is installed
         assert giatools.io.tifffile is not None
 
     def test__input1(self):
-        img = giatools.io.imread('tests/data/input1_uint8_yx.tif')
+        img, axes = giatools.io.imreadraw('tests/data/input1_uint8_yx.tif')
         self.assertEqual(img.mean(), 63.66848655158571)
-        self.assertEqual(img.shape, (1, 1, 265, 329, 1))
-
-    def test__input1__ret_axes(self):
-        img, axes = giatools.io.imread('tests/data/input1_uint8_yx.tif', ret_axes=True)
-        self.assertEqual(img.mean(), 63.66848655158571)
-        self.assertEqual(img.shape, (1, 1, 265, 329, 1))
+        self.assertEqual(img.shape, (265, 329))
         self.assertEqual(axes, 'YX')
 
     def test__input2(self):
-        img = giatools.io.imread('tests/data/input2_uint8_yx.tif')
+        img, axes = giatools.io.imreadraw('tests/data/input2_uint8_yx.tif')
         self.assertEqual(img.mean(), 9.543921821305842)
-        self.assertEqual(img.shape, (1, 1, 96, 97, 1))
+        self.assertEqual(img.shape, (96, 97))
+        self.assertEqual(axes, 'YX')
 
     def test__input3(self):
         """
@@ -38,24 +34,17 @@ class imread__with_tifffile(unittest.TestCase):
 
         For details see: https://github.com/BMCV/galaxy-image-analysis/pull/132#issuecomment-2371561435
         """
-        img = giatools.io.imread('tests/data/input3_uint16_zyx.tif')
-        self.assertEqual(img.shape, (1, 5, 198, 356, 1))
+        img, axes = giatools.io.imreadraw('tests/data/input3_uint16_zyx.tif')
+        self.assertEqual(img.shape, (5, 198, 356))
         self.assertEqual(img.mean(), 1259.6755334241288)
+        self.assertEqual(axes, 'ZYX')
 
     def test__input4(self):
         """
         Test an RGB PNG file, that cannot be loaded with `tifffile`, but works with ``skimage.io.imread``.
         """
-        img = giatools.io.imread('tests/data/input4_uint8.png')
-        self.assertEqual(img.shape, (1, 1, 10, 10, 3))
-        self.assertEqual(img.mean(), 130.04)
-
-    def test__input4__ret_axes(self):
-        """
-        Same as `test__input4`, but with `ret_axes=True`.
-        """
-        img, axes = giatools.io.imread('tests/data/input4_uint8.png', ret_axes=True)
-        self.assertEqual(img.shape, (1, 1, 10, 10, 3))
+        img, axes = giatools.io.imreadraw('tests/data/input4_uint8.png')
+        self.assertEqual(img.shape, (10, 10, 3))
         self.assertEqual(img.mean(), 130.04)
         self.assertEqual(axes, 'YXC')
 
@@ -63,38 +52,42 @@ class imread__with_tifffile(unittest.TestCase):
         """
         Test TIFF file with ``CYX`` axes.
         """
-        img = giatools.io.imread('tests/data/input5_uint8_cyx.tif')
-        self.assertEqual(img.shape, (1, 1, 8, 16, 2))
+        img, axes = giatools.io.imreadraw('tests/data/input5_uint8_cyx.tif')
+        self.assertEqual(img.shape, (2, 8, 16))
         self.assertEqual(img.mean(), 22.25390625)
+        self.assertEqual(axes, 'CYX')
 
     def test__input6(self):
         """
         Test TIFF file with ``ZYX`` axes.
         """
-        img = giatools.io.imread('tests/data/input6_uint8_zyx.tif')
-        self.assertEqual(img.shape, (1, 25, 8, 16, 1))
+        img, axes = giatools.io.imreadraw('tests/data/input6_uint8_zyx.tif')
+        self.assertEqual(img.shape, (25, 8, 16))
         self.assertEqual(img.mean(), 26.555)
+        self.assertEqual(axes, 'ZYX')
 
     def test__input7(self):
         """
         Test TIFF file with ``ZCYX`` axes.
         """
-        img = giatools.io.imread('tests/data/input7_uint8_zcyx.tif')
-        self.assertEqual(img.shape, (1, 25, 50, 50, 2))
+        img, axes = giatools.io.imreadraw('tests/data/input7_uint8_zcyx.tif')
+        self.assertEqual(img.shape, (25, 2, 50, 50))
         self.assertEqual(img.mean(), 14.182152)
+        self.assertEqual(axes, 'ZCYX')
 
     def test__input8(self):
         """
         Test TIFF file with ``TYX`` axes.
         """
-        img = giatools.io.imread('tests/data/input8_uint16_tyx.tif')
-        self.assertEqual(img.shape, (5, 1, 49, 56, 1))
+        img, axes = giatools.io.imreadraw('tests/data/input8_uint16_tyx.tif')
+        self.assertEqual(img.shape, (5, 49, 56))
         self.assertEqual(img.mean(), 5815.486880466472)
+        self.assertEqual(axes, 'TYX')
 
 
 @unittest.mock.patch('skimage.io.imread')
 @unittest.mock.patch('giatools.io.tifffile', None)
-class imread__without_tifffile(unittest.TestCase):
+class imreadraw__without_tifffile(unittest.TestCase):
     """
     Test loading an image without `tifffile` installed.
     """
@@ -105,9 +98,10 @@ class imread__without_tifffile(unittest.TestCase):
         """
         np.random.seed(0)
         mock_skimage_io_imread.return_value = np.random.rand(5, 5)
-        img = giatools.io.imread('tests/data/input1.tif')
+        img, axis = giatools.io.imreadraw('tests/data/input1.tif')
         mock_skimage_io_imread.assert_called_once_with('tests/data/input1.tif')
-        np.testing.assert_array_equal(img, mock_skimage_io_imread.return_value[None, None, :, :, None])
+        np.testing.assert_array_equal(img, mock_skimage_io_imread.return_value)
+        self.assertEqual(axis, 'YX')
 
     def test__yxc(self, mock_skimage_io_imread):
         """
@@ -115,9 +109,10 @@ class imread__without_tifffile(unittest.TestCase):
         """
         np.random.seed(0)
         mock_skimage_io_imread.return_value = np.random.rand(5, 5, 3)
-        img = giatools.io.imread('tests/data/input1.tif')
+        img, axis = giatools.io.imreadraw('tests/data/input1.tif')
         mock_skimage_io_imread.assert_called_once_with('tests/data/input1.tif')
-        np.testing.assert_array_equal(img, mock_skimage_io_imread.return_value[None, None, ...])
+        np.testing.assert_array_equal(img, mock_skimage_io_imread.return_value)
+        self.assertEqual(axis, 'YXC')
 
     def test__unsupported_dimensions(self, mock_skimage_io_imread):
         """
@@ -126,5 +121,12 @@ class imread__without_tifffile(unittest.TestCase):
         np.random.seed(0)
         mock_skimage_io_imread.return_value = np.random.rand(1, 1, 5, 5, 3)
         with self.assertRaises(AssertionError):
-            giatools.io.imread('tests/data/input1.tif')
+            giatools.io.imreadraw('tests/data/input1.tif')
         mock_skimage_io_imread.assert_called_once_with('tests/data/input1.tif')
+
+
+class imread(unittest.TestCase):
+
+    def test__deprecation(self):
+        with self.assertWarns(DeprecationWarning):
+            giatools.io.imread('tests/data/input1_uint8_yx.tif')

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -72,9 +72,10 @@ class move_char(unittest.TestCase):
 class swap_char(unittest.TestCase):
 
     def test(self):
-        self.assertEqual(giatools.util.swap_char('ABC', 0, 1), 'BAC')
-        self.assertEqual(giatools.util.swap_char('ABC', 0, 2), 'CBA')
-        self.assertEqual(giatools.util.swap_char('ABC', 1, 2), 'ACB')
-        self.assertEqual(giatools.util.swap_char('ABC', 0, 0), 'ABC')
-        self.assertEqual(giatools.util.swap_char('ABC', 1, 1), 'ABC')
-        self.assertEqual(giatools.util.swap_char('ABC', 2, 2), 'ABC')
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(giatools.util.swap_char('ABC', 0, 1), 'BAC')
+            self.assertEqual(giatools.util.swap_char('ABC', 0, 2), 'CBA')
+            self.assertEqual(giatools.util.swap_char('ABC', 1, 2), 'ACB')
+            self.assertEqual(giatools.util.swap_char('ABC', 0, 0), 'ABC')
+            self.assertEqual(giatools.util.swap_char('ABC', 1, 1), 'ABC')
+            self.assertEqual(giatools.util.swap_char('ABC', 2, 2), 'ABC')


### PR DESCRIPTION
**Changes:**
- Add `giatools.Image` class,
  - supports axes manipulation
  - stores the original axes of the image
- Add `giatools.io.imreadraw` for reading images without normalization (mostly)
- Increment version to 0.3.2

**Deprecations:**
- `giatools.io.imread`, use `giatools.Image.read` instead
- `giatools.util.swap_char`